### PR TITLE
Use --standalone-role instead of -r and --standalone

### DIFF
--- a/make-cloud.bash
+++ b/make-cloud.bash
@@ -355,12 +355,11 @@ function deploy-standalone {
   sudo openstack tripleo deploy --templates \
                                 --local-ip=${IP}/${NETMASK} \
                                 --control-virtual-ip ${VIP} \
-                                -r /usr/share/openstack-tripleo-heat-templates/roles/Standalone.yaml \
+                                --standalone-role /usr/share/openstack-tripleo-heat-templates/roles/Standalone.yaml \
                                 --environment-file /usr/share/openstack-tripleo-heat-templates/environments/standalone/standalone-tripleo.yaml \
                                 --environment-file ${HOME}/containers-prepare-parameters.yaml \
                                 --environment-file ${HOME}/standalone_parameters.yaml \
                                 --output-dir ${HOME} \
-                                --standalone \
                                 --stack ${STACK_NAME}
 }
 


### PR DESCRIPTION
The --standalone option was removed. Using --standalone-role instead.

https://review.opendev.org/c/openstack/python-tripleoclient/+/753447