### PR TITLE
Fix standalone role

### DIFF
--- a/make-cloud.bash
+++ b/make-cloud.bash
@@ -356,10 +356,11 @@ function deploy-standalone {
   sudo openstack tripleo deploy --templates \
                                 --local-ip=${IP}/${NETMASK} \
                                 --control-virtual-ip ${VIP} \
-                                --standalone-role /usr/share/openstack-tripleo-heat-templates/roles/Standalone.yaml \
+                                -r /usr/share/openstack-tripleo-heat-templates/roles/Standalone.yaml \
                                 --environment-file /usr/share/openstack-tripleo-heat-templates/environments/standalone/standalone-tripleo.yaml \
                                 --environment-file ${HOME}/containers-prepare-parameters.yaml \
                                 --environment-file ${HOME}/standalone_parameters.yaml \
+                                --standalone-role Standalone \
                                 --output-dir ${HOME} \
                                 --stack ${STACK_NAME}
 }


### PR DESCRIPTION
The previous fix to remove the --standalone parameters was incorrect. I
should have kept the --standalone-role parameter and added the
standalone role name instead of passing in the role file. This commit
updates the command so that it's correct for standalone deployments.

  https://github.com/cloudnull/tripleo-deployment-templates/commit/2ef6d8ec26d2ee212e7ee3124d0b0054aa92223b